### PR TITLE
Close README.rst after reading it

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -570,7 +570,8 @@ if not getattr(sys, 'getwindowsversion', None):
 
 readme_path = os.path.join(os.path.abspath(os.path.dirname(__file__)),
                            'README.rst')
-long_desc = open(readme_path, 'r').read()
+with open(readme_path, 'r') as fp:
+    long_desc = fp.read()
 
 setup (name='netifaces',
        version=__version__,


### PR DESCRIPTION
This minor change fixes a warning when using pypy which complains with a
ResourceWarning:

    ResourceWarning: unclosed file <_io.TextIOWrapper name='<snip>/netifaces-0.10.6/README.rst' mode='r' encoding='UTF-8'>