### PR TITLE
Add pypy 2 and pypy 3 to travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,10 @@ matrix:
       python: 2.7
     - os: linux
       python: 3.6
+    - os: linux
+      python: pypy
+    - os: linux
+      python: pypy3
     - os: osx
       language: generic
       env: PYTHON_VERSION=3.6.2


### PR DESCRIPTION
From my experience netifaces works fine with pypy. Let's make sure it stays that way!