### PR TITLE
Add LICENSE and include it in wheel

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2007-2018 Alastair Houghton
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.rst
+++ b/README.rst
@@ -175,27 +175,7 @@ wish to contribute a patch, please use Github to send a pull request.
 4. What license is this under?
 ------------------------------
 
-It's an MIT-style license.  Here goes:
-
-Copyright (c) 2007-2018 Alastair Houghton
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+It's an MIT-style license. See `LICENSE <./LICENSE>`_.
 
 5. Why the jump to 0.10.0?
 --------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,5 @@ tag_build =
 tag_date = 0
 tag_svn_revision = 0
 
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
Thanks for this great library. I really addicted to this.
However, I found that the LICENSE note is in README.rst and it is not really useful when I want to collect all licenses of libraries I used.

So I extract that into `LICENSE` file and include it in wheel by `license_file` explained [here](https://wheel.readthedocs.io/en/stable/#including-the-license-in-the-generated-wheel-file)

<img width="958" alt="alacritty 2018-05-08 17-09-21" src="https://user-images.githubusercontent.com/546312/39745572-93317e98-52e2-11e8-93cc-8b15a1e2d098.png">
