### PR TITLE
Build Windows packages for Python 3.7 on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,8 @@ environment:
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Python37"
+    - PYTHON: "C:\\Python37-x64"
 
 install:
   - "%PYTHON%\\python.exe -m pip install wheel ."

--- a/fetch-win32-wheels
+++ b/fetch-win32-wheels
@@ -15,8 +15,8 @@ fi
 
 niversion=$1
 artifact_url="https://ci.appveyor.com/api/projects/al45tair/netifaces/artifacts"
-win32_versions="27 34 35 36"
-amd64_versions="36"
+win32_versions="27 34 35 36 37"
+amd64_versions="36 37"
 
 for version in $win32_versions; do
     wheel=netifaces-$niversion-cp$version-cp${version}m-win32.whl


### PR DESCRIPTION
It's really nice to have pre-built packages on Windows.