### PR TITLE
Add LICENSE to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
This allows the LICENSE file to be added to the tarball created when
using:

  python setup.py sdist

Signed-off-by: Paul Belanger <pabelanger@redhat.com>