### PR TITLE
Add test.py to the source dist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE
+include test.py


### PR DESCRIPTION
It'd be nice to also include the `test.py` file into the source distribution. This PR attempts to solve it. Here is the output of `python setup.py sdist` command:
```bash
$ python setup.py sdist
running sdist
running egg_info
creating netifaces.egg-info
writing netifaces.egg-info/PKG-INFO
writing dependency_links to netifaces.egg-info/dependency_links.txt
writing top-level names to netifaces.egg-info/top_level.txt
writing manifest file 'netifaces.egg-info/SOURCES.txt'
reading manifest file 'netifaces.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'netifaces.egg-info/SOURCES.txt'
running check
creating netifaces-0.10.9
creating netifaces-0.10.9/netifaces.egg-info
copying files to netifaces-0.10.9...
copying LICENSE -> netifaces-0.10.9
copying MANIFEST.in -> netifaces-0.10.9
copying README.rst -> netifaces-0.10.9
copying netifaces.c -> netifaces-0.10.9
copying setup.cfg -> netifaces-0.10.9
copying setup.py -> netifaces-0.10.9
copying test.py -> netifaces-0.10.9
copying netifaces.egg-info/PKG-INFO -> netifaces-0.10.9/netifaces.egg-info
copying netifaces.egg-info/SOURCES.txt -> netifaces-0.10.9/netifaces.egg-info
copying netifaces.egg-info/dependency_links.txt -> netifaces-0.10.9/netifaces.egg-info
copying netifaces.egg-info/top_level.txt -> netifaces-0.10.9/netifaces.egg-info
copying netifaces.egg-info/zip-safe -> netifaces-0.10.9/netifaces.egg-info
Writing netifaces-0.10.9/setup.cfg
creating dist
Creating tar archive
removing 'netifaces-0.10.9' (and everything under it)
```
See the `copying test.py -> netifaces-0.10.9` added line.

Any thoughts on making the test [pytest](https://docs.pytest.org/en/latest/)-compatible?