### PR TITLE
Added Windows/Linux Python 3.8 builds to CI pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,10 @@ matrix:
       python: 3.5
     - os: linux
       python: 3.6
+    - os: linux
+      python: 3.7
+    - os: linux
+      python: 3.8
     - os: osx
       language: generic
       env: PYTHON_VERSION=3.6.2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,9 @@ environment:
     - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37"
     - PYTHON: "C:\\Python37-x64"
+    - PYTHON: "C:\\Python38"
+    - PYTHON: "C:\\Python38-x64"
+
 
 install:
   - "%PYTHON%\\python.exe -m pip install wheel ."

--- a/fetch-win32-wheels
+++ b/fetch-win32-wheels
@@ -15,8 +15,8 @@ fi
 
 niversion=$1
 artifact_url="https://ci.appveyor.com/api/projects/al45tair/netifaces/artifacts"
-win32_versions="27 34 35 36 37"
-amd64_versions="36 37"
+win32_versions="27 34 35 36 37 38"
+amd64_versions="36 37 38"
 
 for version in $win32_versions; do
     wheel=netifaces-$niversion-cp$version-cp${version}m-win32.whl

--- a/pypi_windows_packages.bat
+++ b/pypi_windows_packages.bat
@@ -1,6 +1,12 @@
 C:\Python27\python.exe setup.py clean bdist_egg bdist_wininst bdist_wheel %*
 C:\Python34\python.exe setup.py clean bdist_egg bdist_wininst bdist_wheel %*
 C:\Python35\python.exe setup.py clean bdist_egg bdist_wininst bdist_wheel %*
+C:\Python36\python.exe setup.py clean bdist_egg bdist_wininst bdist_wheel %*
+C:\Python37\python.exe setup.py clean bdist_egg bdist_wininst bdist_wheel %*
+C:\Python38\python.exe setup.py clean bdist_egg bdist_wininst bdist_wheel %*
 C:\Python27_32\python.exe setup.py clean bdist_egg bdist_wininst bdist_wheel %*
 C:\Python34_32\python.exe setup.py clean bdist_egg bdist_wininst bdist_wheel %*
 C:\Python35_32\python.exe setup.py clean bdist_egg bdist_wininst bdist_wheel %*
+C:\Python36_32\python.exe setup.py clean bdist_egg bdist_wininst bdist_wheel %*
+C:\Python37_32\python.exe setup.py clean bdist_egg bdist_wininst bdist_wheel %*
+C:\Python38_32\python.exe setup.py clean bdist_egg bdist_wininst bdist_wheel %*

--- a/setup.py
+++ b/setup.py
@@ -589,12 +589,12 @@ setup (name='netifaces',
     'Topic :: System :: Networking',
     'Programming Language :: Python',
     'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.5',
-    'Programming Language :: Python :: 2.6',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
-    'Programming Language :: Python :: 3.6'
+    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8'
     ],
        ext_modules=[iface_mod])


### PR DESCRIPTION
Python 3.8 is becoming more prevalent on OS platforms and is the default Python3 install on Ubuntu 20.04 LTS.

This branch adds Python 3.8 builds for Windows and Linux platforms by updating the AppVeyor and Travis CI pipelines.  Verified new builds worked in local CI accounts, though the old 2.7/3.4/3.5 Windows builds [appeared to fail](https://ci.appveyor.com/project/chugcup/netifaces/builds/32622644) on my local job due to Visual Studio C++ environment issues.

Was not sure the best way to target/update the MacOS builds containing a subminor version, but I imagine that may be quick change once these are included.