### PR TITLE
Replace PyUnicode_FromUnicode

### DIFF
--- a/netifaces.c
+++ b/netifaces.c
@@ -1567,7 +1567,7 @@ gateways (PyObject *self)
 	  break;
 	}
 
-	ifname = PyUnicode_FromWideChar (pwcsName, -1);
+	ifname = PyUnicode_FromWideChar (pwcsName, wcslen (pwcsName));
 	isdefault = bBest ? Py_True : Py_False;
 
 	tuple = PyTuple_Pack (3, gateway, ifname, isdefault);
@@ -1674,7 +1674,7 @@ gateways (PyObject *self)
       if (bBest)
         dwBestMetric = table->table[n].dwForwardMetric1;
 
-      ifname = PyUnicode_FromWideChar (pwcsName, -1);
+      ifname = PyUnicode_FromWideChar (pwcsName, wcslen (pwcsName));
       gateway = PyUnicode_FromString (gwbuf);
       isdefault = bBest ? Py_True : Py_False;
 

--- a/netifaces.c
+++ b/netifaces.c
@@ -1567,7 +1567,7 @@ gateways (PyObject *self)
 	  break;
 	}
 
-	ifname = PyUnicode_FromUnicode (pwcsName, wcslen (pwcsName));
+	ifname = PyUnicode_FromWideChar (pwcsName, -1);
 	isdefault = bBest ? Py_True : Py_False;
 
 	tuple = PyTuple_Pack (3, gateway, ifname, isdefault);
@@ -1674,7 +1674,7 @@ gateways (PyObject *self)
       if (bBest)
         dwBestMetric = table->table[n].dwForwardMetric1;
 
-      ifname = PyUnicode_FromUnicode (pwcsName, wcslen (pwcsName));
+      ifname = PyUnicode_FromWideChar (pwcsName, -1);
       gateway = PyUnicode_FromString (gwbuf);
       isdefault = bBest ? Py_True : Py_False;
 


### PR DESCRIPTION
PyUnicode_FromUnicode is deprecated since Python 3.3.
Replace it with PyUnicode_FromWideChar.