### PR TITLE
Build cp27 wheels for 64 bit Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ environment:
 
   matrix:
     - PYTHON: "C:\\Python27"
+    - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"

--- a/fetch-win32-wheels
+++ b/fetch-win32-wheels
@@ -16,7 +16,7 @@ fi
 niversion=$1
 artifact_url="https://ci.appveyor.com/api/projects/al45tair/netifaces/artifacts"
 win32_versions="27 34 35 36 37 38"
-amd64_versions="36 37 38"
+amd64_versions="27 36 37 38"
 
 for version in $win32_versions; do
     wheel=netifaces-$niversion-cp$version-cp${version}m-win32.whl


### PR DESCRIPTION
This addresses issue #47. 

I have not been able to verify that the `fetch-win32-wheels` script actually works (because of path differences), but the `netifaces-0.10.9-cp27-cp27m-win_amd64.whl` package generated by appveyor ([here](https://ci.appveyor.com/project/sajith/netifaces/build/job/fen72m4lm775nypl)) works fine.  I have tested it locally.

Would you be able to make a new release, please? :-)

Here's the background: I was hoping to get rid of [Tahoe-LAFS](https://github.com/tahoe-lafs/tahoe-lafs/) project's dependency on vcpython27, both for CI and for non-CI uses.  It used to be that [zfec](https://github.com/tahoe-lafs/zfec) package was the one dependency that needed vcpython27.  I recently addressed that with a new release of zfec with wheels for various platforms.  In the meanwhile, Tahoe-LAFS also started using netifaces, which put the vcpython27 dependency right back.  (This won't be a problem once Tahoe-LAFS completes Python 3 port, but that work is still in progress.)

(Incidentally, I have found that [cibuildwheel](https://pypi.org/project/cibuildwheel/) is helpful in packaging zfec.  I can start a PR that will package netifaces using cibuildwheels, if there's interest in that.)
