### PR TITLE
[NETLINK] Add support for empty destination, and empty metric

### DIFF
--- a/netifaces.c
+++ b/netifaces.c
@@ -1894,8 +1894,14 @@ gateways (PyObject *self)
           attr = RTA_NEXT(attr, len);
         }
 
+        static const unsigned char ipv4_default[4] = {};
+        static const unsigned char ipv6_default[16] = {};
+
         /* We're looking for gateways with no destination */
-        if (!dst && gw && ifndx >= 0) {
+        if ((!dst
+            || (pmsg->rt.rtm_family == AF_INET && !memcmp(dst, ipv4_default, sizeof(ipv4_default)))
+            || (pmsg->rt.rtm_family == AF_INET6 && !memcmp(dst, ipv6_default, sizeof(ipv6_default)))
+        ) && gw && ifndx >= 0) {
           char buffer[256];
           char ifnamebuf[IF_NAMESIZE];
           char *ifname;


### PR DESCRIPTION
Had an interesting issue where the following routing table wasn't showing my 'tun0' device in `netiface.gateways()` :

```
Kernel IP routing table
Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
0.0.0.0         10.58.112.1     128.0.0.0       UG    0      0        0 tun0
0.0.0.0         192.168.1.1     0.0.0.0         UG    100    0        0 eth0
10.58.112.0     0.0.0.0         255.255.255.0   U     0      0        0 tun0
128.0.0.0       10.58.112.1     128.0.0.0       UG    0      0        0 tun0
156.146.62.251  192.168.1.1     255.255.255.255 UGH   0      0        0 eth0
192.168.1.0     0.0.0.0         255.255.255.0   U     100    0        0 eth0
```

```
$ python
Python 3.8.6 (default, Nov 16 2020, 22:08:49) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import netifaces
>>> netifaces.gateways()
{'default': {2: ('192.168.1.1', 'eth0')}, 2: [('192.168.1.1', 'eth0', True)]}
```

Upon further debugging, i discovered that the "dst" variable was getting a **non-null return**, though its "network format address" representation in memory was full of nothing but 0's for IPV4 addresses.

This patch has a workaround for routing tables that get this kind default route inserted into them.  I'm pretty sure this is a perfectly valid use case on Linux, because openvpn was the software that inserted this "tun0" routing table entry like this.

After the fix, I get this:

```
$ python
Python 3.8.6 (default, Nov 16 2020, 22:08:49) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import netifaces
>>> netifaces.gateways()
{'default': {2: ('192.168.1.1', 'eth0')}, 2: [('10.28.112.1', 'tun0', True), ('192.168.1.1', 'eth0', True)]}
```