### PR TITLE
Added new function for getting all network interfaces at the same time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ matrix:
       python: 3.7
     - os: linux
       python: 3.8
+    - os: linux
+      python: 3.9
     - os: osx
       language: generic
       env: PYTHON_VERSION=3.6.2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,8 @@ environment:
     - PYTHON: "C:\\Python37-x64"
     - PYTHON: "C:\\Python38"
     - PYTHON: "C:\\Python38-x64"
+    - PYTHON: "C:\\Python39"
+    - PYTHON: "C:\\Python39-x64"
 
 
 install:

--- a/fetch-win32-wheels
+++ b/fetch-win32-wheels
@@ -15,8 +15,8 @@ fi
 
 niversion=$1
 artifact_url="https://ci.appveyor.com/api/projects/al45tair/netifaces/artifacts"
-win32_versions="27 34 35 36 37 38"
-amd64_versions="36 37 38"
+win32_versions="27 34 35 36 37 38 39"
+amd64_versions="36 37 38 39"
 
 for version in $win32_versions; do
     wheel=netifaces-$niversion-cp$version-cp${version}m-win32.whl

--- a/netifaces.c
+++ b/netifaces.c
@@ -688,106 +688,270 @@ string_from_address(SOCKADDR *addr, DWORD addrlen)
 static int
 add_to_family (PyObject *result, int family, PyObject *obj)
 {
-  PyObject *py_family;
-  PyObject *list;
+    PyObject *py_family;
+    PyObject *list;
 
-  if (!PyObject_Size (obj))
-    return TRUE;
+    if (!PyObject_Size (obj))
+        return TRUE;
 
-  py_family = PyInt_FromLong (family);
-  list = PyDict_GetItem (result, py_family);
+    py_family = PyInt_FromLong (family);
+    list = PyDict_GetItem (result, py_family);
 
-  if (!py_family) {
-    Py_DECREF (obj);
-    Py_XDECREF (list);
-    return FALSE;
-  }
-
-  if (!list) {
-    list = PyList_New (1);
-    if (!list) {
-      Py_DECREF (obj);
-      Py_DECREF (py_family);
-      return FALSE;
+    if (!py_family) {
+        Py_DECREF (obj);
+        Py_XDECREF (list);
+        return FALSE;
     }
 
-    PyList_SET_ITEM (list, 0, obj);
-    PyDict_SetItem (result, py_family, list);
-    Py_DECREF (list);
-  } else {
-    PyList_Append (list, obj);
-    Py_DECREF (obj);
-  }
+    if (!list) {
+        list = PyList_New (1);
+        if (!list) {
+            Py_DECREF (obj);
+            Py_DECREF (py_family);
+            return FALSE;
+        }
 
-  return TRUE;
+        PyList_SET_ITEM (list, 0, obj);
+        PyDict_SetItem (result, py_family, list);
+        Py_DECREF (list);
+    } else {
+        PyList_Append (list, obj);
+        Py_DECREF (obj);
+    }
+
+    return TRUE;
 }
 
-/* -- ifaddresses() --------------------------------------------------------- */
-
-static PyObject *
-ifaddrs (PyObject *self, PyObject *args)
+#if HAVE_GETIFADDRS
+static PyObject* getifaddrsinfo(struct ifaddrs *addr)
 {
-  const char *ifname;
-  PyObject *result;
-  int found = FALSE;
-#if defined(WIN32)
-  PIP_ADAPTER_ADDRESSES pAdapterAddresses = NULL, pInfo = NULL;
-  ULONG ulBufferLength = 0;
-  DWORD dwRet;
-  PIP_ADAPTER_UNICAST_ADDRESS pUniAddr;
-#elif HAVE_GETIFADDRS
-  struct ifaddrs *addrs = NULL;
-  struct ifaddrs *addr = NULL;
+    /* Sometimes there are records without addresses (e.g. in the case of a
+       dial-up connection via ppp, which on Linux can have a link address
+       record with no actual address).  We skip these as they aren't useful.
+       Thanks to Christian Kauhaus for reporting this issue. */
+    if (!addr->ifa_addr)
+      return NULL;
+
+    char buffer[256];
+    PyObject *pyaddr = NULL, *netmask = NULL, *braddr = NULL, *flags = NULL;
+
+#if HAVE_IPV6_SOCKET_IOCTLS
+    /* For IPv6 addresses we try to get the flags. */
+    if (addr->ifa_addr->sa_family == AF_INET6) {
+      struct sockaddr_in6 *sin;
+      struct in6_ifreq ifr6;
+
+      int sock6 = socket (AF_INET6, SOCK_DGRAM, 0);
+
+      if (sock6 < 0) {
+        PyErr_SetFromErrno (PyExc_OSError);
+        return NULL;
+      }
+
+      sin = (struct sockaddr_in6 *)addr->ifa_addr;
+      strncpy (ifr6.ifr_name, addr->ifa_name, IFNAMSIZ);
+      ifr6.ifr_addr = *sin;
+
+      if (ioctl (sock6, SIOCGIFAFLAG_IN6, &ifr6) >= 0) {
+        flags = PyLong_FromUnsignedLong (ifr6.ifr_ifru.ifru_flags6);
+      }
+
+      close (sock6);
+    }
+#endif /* HAVE_IPV6_SOCKET_IOCTLS */
+
+    if (string_from_sockaddr (addr->ifa_addr, buffer, sizeof (buffer)) == 0)
+      pyaddr = PyUnicode_FromString (buffer);
+
+    if (string_from_netmask (addr->ifa_netmask, buffer, sizeof (buffer)) == 0)
+      netmask = PyUnicode_FromString (buffer);
+
+    if (string_from_sockaddr (addr->ifa_broadaddr, buffer, sizeof (buffer)) == 0)
+      braddr = PyUnicode_FromString (buffer);
+
+    /* Cygwin's implementation of getaddrinfo() is buggy and returns broadcast
+       addresses for 169.254.0.0/16.  Nix them here. */
+    if (addr->ifa_addr->sa_family == AF_INET) {
+      struct sockaddr_in *sin = (struct sockaddr_in *)addr->ifa_addr;
+
+      if ((ntohl(sin->sin_addr.s_addr) & 0xffff0000) == 0xa9fe0000) {
+        Py_XDECREF (braddr);
+        braddr = NULL;
+      }
+    }
+
+    {
+      PyObject *dict = PyDict_New();
+
+      if (!dict) {
+        Py_XDECREF (pyaddr);
+        Py_XDECREF (netmask);
+        Py_XDECREF (braddr);
+        Py_XDECREF (flags);
+        return NULL;
+      }
+
+      if (pyaddr)
+        PyDict_SetItemString (dict, "addr", pyaddr);
+      if (netmask)
+        PyDict_SetItemString (dict, "netmask", netmask);
+
+      if (braddr) {
+        if (addr->ifa_flags & (IFF_POINTOPOINT | IFF_LOOPBACK))
+          PyDict_SetItemString (dict, "peer", braddr);
+        else
+          PyDict_SetItemString (dict, "broadcast", braddr);
+      }
+
+      if (flags)
+        PyDict_SetItemString (dict, "flags", flags);
+
+      Py_XDECREF (pyaddr);
+      Py_XDECREF (netmask);
+      Py_XDECREF (braddr);
+      Py_XDECREF (flags);
+
+      return dict;
+    }
+}
 #endif
 
-  if (!PyArg_ParseTuple (args, "s", &ifname))
-    return NULL;
-
-  result = PyDict_New ();
-
+#if HAVE_SOCKET_IOCTLS
+static PyObject* socket_ioctls_info(const char* ifname, int sock)
+{
+  PyObject* result = PyDict_New ();
   if (!result)
     return NULL;
 
-#if defined(WIN32)
-  /* .. Win32 ............................................................... */
+  struct CNAME(ifreq) ifr;
+  PyObject *addr = NULL, *netmask = NULL, *braddr = NULL, *dstaddr = NULL;
+  int is_p2p = FALSE;
+  char buffer[256];
 
-  /* First, retrieve the adapter information.  We do this in a loop, in
-     case someone adds or removes adapters in the meantime. */
-  do {
-    dwRet = GetAdaptersAddresses (AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, NULL,
-                                  pAdapterAddresses, &ulBufferLength);
+  strncpy (ifr.CNAME(ifr_name), ifname, IFNAMSIZ);
 
-    if (dwRet == ERROR_BUFFER_OVERFLOW) {
-      if (pAdapterAddresses)
-        free (pAdapterAddresses);
-      pAdapterAddresses = (PIP_ADAPTER_ADDRESSES)malloc (ulBufferLength);
+#if HAVE_SIOCGIFHWADDR
+  if (ioctl (sock, SIOCGIFHWADDR, &ifr) == 0) {
 
-      if (!pAdapterAddresses) {
+    if (string_from_sockaddr ((struct sockaddr *)&ifr.CNAME(ifr_addr), buffer, sizeof (buffer)) == 0) {
+      PyObject *hwaddr = PyUnicode_FromString (buffer);
+      PyObject *dict = PyDict_New ();
+
+      if (!hwaddr || !dict) {
+        Py_XDECREF (hwaddr);
+        Py_XDECREF (dict);
+        Py_XDECREF (result);
+        return NULL;
+      }
+
+      PyDict_SetItemString (dict, "addr", hwaddr);
+      Py_DECREF (hwaddr);
+
+      if (!add_to_family (result, AF_LINK, dict)) {
         Py_DECREF (result);
-        PyErr_SetString (PyExc_MemoryError, "Not enough memory");
         return NULL;
       }
     }
-  } while (dwRet == ERROR_BUFFER_OVERFLOW);
-
-  /* If we failed, then fail in Python too */
-  if (dwRet != ERROR_SUCCESS && dwRet != ERROR_NO_DATA) {
-    Py_DECREF (result);
-    if (pAdapterAddresses)
-      free (pAdapterAddresses);
-
-    PyErr_SetString (PyExc_OSError,
-                     "Unable to obtain adapter information.");
-    return NULL;
   }
+#endif
 
-  for (pInfo = pAdapterAddresses; pInfo; pInfo = pInfo->Next) {
+#if HAVE_SIOCGIFADDR
+#if HAVE_SIOCGLIFNUM
+  if (ioctl (sock, SIOCGLIFADDR, &ifr) == 0) {
+#else
+  if (ioctl (sock, SIOCGIFADDR, &ifr) == 0) {
+#endif
+    if (string_from_sockaddr ((struct sockaddr *)&ifr.CNAME(ifr_addr), buffer, sizeof (buffer)) == 0)
+      addr = PyUnicode_FromString (buffer);
+  }
+#endif
+
+#if HAVE_SIOCGIFNETMASK
+#if HAVE_SIOCGLIFNUM
+  if (ioctl (sock, SIOCGLIFNETMASK, &ifr) == 0) {
+#else
+  if (ioctl (sock, SIOCGIFNETMASK, &ifr) == 0) {
+#endif
+    if (string_from_sockaddr ((struct sockaddr *)&ifr.CNAME(ifr_addr), buffer, sizeof (buffer)) == 0)
+      netmask = PyUnicode_FromString (buffer);
+  }
+#endif
+
+#if HAVE_SIOCGIFFLAGS
+#if HAVE_SIOCGLIFNUM
+  if (ioctl (sock, SIOCGLIFFLAGS, &ifr) == 0) {
+#else
+  if (ioctl (sock, SIOCGIFFLAGS, &ifr) == 0) {
+#endif
+    if (ifr.CNAME(ifr_flags) & IFF_POINTOPOINT)
+      is_p2p = TRUE;
+  }
+#endif
+
+#if HAVE_SIOCGIFBRDADDR
+#if HAVE_SIOCGLIFNUM
+  if (!is_p2p && ioctl (sock, SIOCGLIFBRDADDR, &ifr) == 0) {
+#else
+  if (!is_p2p && ioctl (sock, SIOCGIFBRDADDR, &ifr) == 0) {
+#endif
+    if (string_from_sockaddr ((struct sockaddr *)&ifr.CNAME(ifr_addr), buffer, sizeof (buffer)) == 0)
+      braddr = PyUnicode_FromString (buffer);
+  }
+#endif
+
+#if HAVE_SIOCGIFDSTADDR
+#if HAVE_SIOCGLIFNUM
+  if (is_p2p && ioctl (sock, SIOCGLIFBRDADDR, &ifr) == 0) {
+#else
+  if (is_p2p && ioctl (sock, SIOCGIFBRDADDR, &ifr) == 0) {
+#endif
+    if (string_from_sockaddr ((struct sockaddr *)&ifr.CNAME(ifr_addr), buffer, sizeof (buffer)) == 0)
+      dstaddr = PyUnicode_FromString (buffer);
+  }
+#endif
+    PyObject *dict = PyDict_New();
+
+    if (!dict) {
+      Py_XDECREF (addr);
+      Py_XDECREF (netmask);
+      Py_XDECREF (braddr);
+      Py_XDECREF (dstaddr);
+      Py_DECREF (result);
+      return NULL;
+    }
+
+    if (addr)
+      PyDict_SetItemString (dict, "addr", addr);
+    if (netmask)
+      PyDict_SetItemString (dict, "netmask", netmask);
+    if (braddr)
+      PyDict_SetItemString (dict, "broadcast", braddr);
+    if (dstaddr)
+      PyDict_SetItemString (dict, "peer", dstaddr);
+
+    Py_XDECREF (addr);
+    Py_XDECREF (netmask);
+    Py_XDECREF (braddr);
+    Py_XDECREF (dstaddr);
+
+    if (!add_to_family (result, AF_INET, dict)) {
+        Py_DECREF (result);
+        return NULL;
+    }
+
+    return result;
+}
+#endif
+
+#if defined(WIN32)
+static PyObject* winifaddrinfo(PIP_ADAPTER_ADDRESSES pInfo)
+{
+    PIP_ADAPTER_UNICAST_ADDRESS pUniAddr;
+    PyObject* result = PyDict_New();
+    if(!result)
+        return NULL;
+
     char buffer[256];
-
-    if (strcmp (pInfo->AdapterName, ifname) != 0)
-      continue;
-
-    found = TRUE;
 
     /* Do the physical address */
     if (256 >= 3 * pInfo->PhysicalAddressLength) {
@@ -808,7 +972,6 @@ ifaddrs (PyObject *self, PyObject *args)
       if (!dict) {
         Py_XDECREF (hwaddr);
         Py_DECREF (result);
-        free (pAdapterAddresses);
         return NULL;
       }
 
@@ -817,7 +980,6 @@ ifaddrs (PyObject *self, PyObject *args)
 
       if (!add_to_family (result, AF_LINK, dict)) {
         Py_DECREF (result);
-        free (pAdapterAddresses);
         return NULL;
       }
     }
@@ -986,7 +1148,6 @@ ifaddrs (PyObject *self, PyObject *args)
           Py_XDECREF (mask);
           Py_XDECREF (bcast);
           Py_DECREF (result);
-          free (pAdapterAddresses);
           return NULL;
         }
 
@@ -1003,11 +1164,82 @@ ifaddrs (PyObject *self, PyObject *args)
 
         if (!add_to_family (result, family, dict)) {
           Py_DECREF (result);
-          free ((void *)pAdapterAddresses);
           return NULL;
         }
       }
     }
+    return result;
+}
+#endif
+
+/* -- ifaddresses() --------------------------------------------------------- */
+
+static PyObject *
+ifaddrs (PyObject *self, PyObject *args)
+{
+  const char *ifname;
+  PyObject *result;
+  int found = FALSE;
+#if defined(WIN32)
+  PIP_ADAPTER_ADDRESSES pAdapterAddresses = NULL, pInfo = NULL;
+  ULONG ulBufferLength = 0;
+  DWORD dwRet;
+#elif HAVE_GETIFADDRS
+  struct ifaddrs *addrs = NULL;
+  struct ifaddrs *addr = NULL;
+#endif
+
+  if (!PyArg_ParseTuple (args, "s", &ifname))
+    return NULL;
+
+  result = PyDict_New ();
+
+  if (!result)
+    return NULL;
+
+#if defined(WIN32)
+  /* .. Win32 ............................................................... */
+
+  /* First, retrieve the adapter information.  We do this in a loop, in
+     case someone adds or removes adapters in the meantime. */
+  do {
+    dwRet = GetAdaptersAddresses (AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, NULL,
+                                  pAdapterAddresses, &ulBufferLength);
+
+    if (dwRet == ERROR_BUFFER_OVERFLOW) {
+      if (pAdapterAddresses)
+        free (pAdapterAddresses);
+      pAdapterAddresses = (PIP_ADAPTER_ADDRESSES)malloc (ulBufferLength);
+
+      if (!pAdapterAddresses) {
+        Py_DECREF (result);
+        PyErr_SetString (PyExc_MemoryError, "Not enough memory");
+        return NULL;
+      }
+    }
+  } while (dwRet == ERROR_BUFFER_OVERFLOW);
+
+  /* If we failed, then fail in Python too */
+  if (dwRet != ERROR_SUCCESS && dwRet != ERROR_NO_DATA) {
+    Py_DECREF (result);
+    if (pAdapterAddresses)
+      free (pAdapterAddresses);
+
+    PyErr_SetString (PyExc_OSError,
+                     "Unable to obtain adapter information.");
+    return NULL;
+  }
+
+  for (pInfo = pAdapterAddresses; pInfo; pInfo = pInfo->Next) {
+      if (strcmp (pInfo->AdapterName, ifname) != 0)
+        continue;
+
+      result = winifaddrinfo(pInfo);
+      if(!result)
+          continue;
+
+      found = TRUE;
+      break;
   }
 
   free ((void *)pAdapterAddresses);
@@ -1021,109 +1253,20 @@ ifaddrs (PyObject *self, PyObject *args)
   }
 
   for (addr = addrs; addr; addr = addr->ifa_next) {
-    char buffer[256];
-    PyObject *pyaddr = NULL, *netmask = NULL, *braddr = NULL, *flags = NULL;
-
     if (addr->ifa_name == NULL || strcmp (addr->ifa_name, ifname) != 0)
       continue;
- 
-    /* We mark the interface as found, even if there are no addresses;
-       this results in sensible behaviour for these few cases. */
-    found = TRUE;
 
-    /* Sometimes there are records without addresses (e.g. in the case of a
-       dial-up connection via ppp, which on Linux can have a link address
-       record with no actual address).  We skip these as they aren't useful.
-       Thanks to Christian Kauhaus for reporting this issue. */
-    if (!addr->ifa_addr)
-      continue;
-      
-#if HAVE_IPV6_SOCKET_IOCTLS
-    /* For IPv6 addresses we try to get the flags. */
-    if (addr->ifa_addr->sa_family == AF_INET6) {
-      struct sockaddr_in6 *sin;
-      struct in6_ifreq ifr6;
-      
-      int sock6 = socket (AF_INET6, SOCK_DGRAM, 0);
-
-      if (sock6 < 0) {
-        Py_DECREF (result);
-        PyErr_SetFromErrno (PyExc_OSError);
-        freeifaddrs (addrs);
-        return NULL;
-      }
-      
-      sin = (struct sockaddr_in6 *)addr->ifa_addr;
-      strncpy (ifr6.ifr_name, addr->ifa_name, IFNAMSIZ);
-      ifr6.ifr_addr = *sin;
-      
-      if (ioctl (sock6, SIOCGIFAFLAG_IN6, &ifr6) >= 0) {
-        flags = PyLong_FromUnsignedLong (ifr6.ifr_ifru.ifru_flags6);
+      PyObject* ifinfo = getifaddrsinfo(addr);
+      if (ifinfo != NULL)
+      {
+          found = TRUE;
       }
 
-      close (sock6);
-    }
-#endif /* HAVE_IPV6_SOCKET_IOCTLS */
-
-    if (string_from_sockaddr (addr->ifa_addr, buffer, sizeof (buffer)) == 0)
-      pyaddr = PyUnicode_FromString (buffer);
-
-    if (string_from_netmask (addr->ifa_netmask, buffer, sizeof (buffer)) == 0)
-      netmask = PyUnicode_FromString (buffer);
-
-    if (string_from_sockaddr (addr->ifa_broadaddr, buffer, sizeof (buffer)) == 0)
-      braddr = PyUnicode_FromString (buffer);
-
-    /* Cygwin's implementation of getaddrinfo() is buggy and returns broadcast
-       addresses for 169.254.0.0/16.  Nix them here. */
-    if (addr->ifa_addr->sa_family == AF_INET) {
-      struct sockaddr_in *sin = (struct sockaddr_in *)addr->ifa_addr;
-
-      if ((ntohl(sin->sin_addr.s_addr) & 0xffff0000) == 0xa9fe0000) {
-        Py_XDECREF (braddr);
-        braddr = NULL;
-      }
-    }
-
-    {
-      PyObject *dict = PyDict_New();
-
-      if (!dict) {
-        Py_XDECREF (pyaddr);
-        Py_XDECREF (netmask);
-        Py_XDECREF (braddr);
-        Py_XDECREF (flags);
+      if (!add_to_family (result, addr->ifa_addr->sa_family, ifinfo)) {
         Py_DECREF (result);
         freeifaddrs (addrs);
         return NULL;
       }
-
-      if (pyaddr)
-        PyDict_SetItemString (dict, "addr", pyaddr);
-      if (netmask)
-        PyDict_SetItemString (dict, "netmask", netmask);
-
-      if (braddr) {
-        if (addr->ifa_flags & (IFF_POINTOPOINT | IFF_LOOPBACK))
-          PyDict_SetItemString (dict, "peer", braddr);
-        else
-          PyDict_SetItemString (dict, "broadcast", braddr);
-      }
-      
-      if (flags)
-        PyDict_SetItemString (dict, "flags", flags);
-
-      Py_XDECREF (pyaddr);
-      Py_XDECREF (netmask);
-      Py_XDECREF (braddr);
-      Py_XDECREF (flags);
-
-      if (!add_to_family (result, addr->ifa_addr->sa_family, dict)) {
-        Py_DECREF (result);
-        freeifaddrs (addrs);
-        return NULL;
-      }
-    }
   }
 
   freeifaddrs (addrs);
@@ -1138,140 +1281,11 @@ ifaddrs (PyObject *self, PyObject *args)
     return NULL;
   }
 
-  struct CNAME(ifreq) ifr;
-  PyObject *addr = NULL, *netmask = NULL, *braddr = NULL, *dstaddr = NULL;
-  int is_p2p = FALSE;
-  char buffer[256];
-
-  strncpy (ifr.CNAME(ifr_name), ifname, IFNAMSIZ);
-
-#if HAVE_SIOCGIFHWADDR
-  if (ioctl (sock, SIOCGIFHWADDR, &ifr) == 0) {
-    found = TRUE;
-
-    if (string_from_sockaddr ((struct sockaddr *)&ifr.CNAME(ifr_addr), buffer, sizeof (buffer)) == 0) {
-      PyObject *hwaddr = PyUnicode_FromString (buffer);
-      PyObject *dict = PyDict_New ();
-
-      if (!hwaddr || !dict) {
-        Py_XDECREF (hwaddr);
-        Py_XDECREF (dict);
-        Py_XDECREF (result);
-        close (sock);
-        return NULL;
-      }
-
-      PyDict_SetItemString (dict, "addr", hwaddr);
-      Py_DECREF (hwaddr);
-
-      if (!add_to_family (result, AF_LINK, dict)) {
-        Py_DECREF (result);
-        close (sock);
-        return NULL;
-      }
-    }
-  }
-#endif
-
-#if HAVE_SIOCGIFADDR
-#if HAVE_SIOCGLIFNUM
-  if (ioctl (sock, SIOCGLIFADDR, &ifr) == 0) {
-#else
-  if (ioctl (sock, SIOCGIFADDR, &ifr) == 0) {
-#endif
-    found = TRUE;
-
-    if (string_from_sockaddr ((struct sockaddr *)&ifr.CNAME(ifr_addr), buffer, sizeof (buffer)) == 0)
-      addr = PyUnicode_FromString (buffer);
-  }
-#endif
-
-#if HAVE_SIOCGIFNETMASK
-#if HAVE_SIOCGLIFNUM
-  if (ioctl (sock, SIOCGLIFNETMASK, &ifr) == 0) {
-#else
-  if (ioctl (sock, SIOCGIFNETMASK, &ifr) == 0) {
-#endif
-    found = TRUE;
-
-    if (string_from_sockaddr ((struct sockaddr *)&ifr.CNAME(ifr_addr), buffer, sizeof (buffer)) == 0)
-      netmask = PyUnicode_FromString (buffer);
-  }
-#endif
-
-#if HAVE_SIOCGIFFLAGS
-#if HAVE_SIOCGLIFNUM
-  if (ioctl (sock, SIOCGLIFFLAGS, &ifr) == 0) {
-#else
-  if (ioctl (sock, SIOCGIFFLAGS, &ifr) == 0) {
-#endif
-    found = TRUE;
-
-    if (ifr.CNAME(ifr_flags) & IFF_POINTOPOINT)
-      is_p2p = TRUE;
-  }
-#endif
-
-#if HAVE_SIOCGIFBRDADDR
-#if HAVE_SIOCGLIFNUM
-  if (!is_p2p && ioctl (sock, SIOCGLIFBRDADDR, &ifr) == 0) {
-#else
-  if (!is_p2p && ioctl (sock, SIOCGIFBRDADDR, &ifr) == 0) {
-#endif
-    found = TRUE;
-
-    if (string_from_sockaddr ((struct sockaddr *)&ifr.CNAME(ifr_addr), buffer, sizeof (buffer)) == 0)
-      braddr = PyUnicode_FromString (buffer);
-  }
-#endif
-
-#if HAVE_SIOCGIFDSTADDR
-#if HAVE_SIOCGLIFNUM
-  if (is_p2p && ioctl (sock, SIOCGLIFBRDADDR, &ifr) == 0) {
-#else
-  if (is_p2p && ioctl (sock, SIOCGIFBRDADDR, &ifr) == 0) {
-#endif
-    found = TRUE;
-
-    if (string_from_sockaddr ((struct sockaddr *)&ifr.CNAME(ifr_addr), buffer, sizeof (buffer)) == 0)
-      dstaddr = PyUnicode_FromString (buffer);
-  }
-#endif
-
+  result = socket_ioctls_info(ifname, sock);
+  if(result != NULL)
   {
-    PyObject *dict = PyDict_New();
-
-    if (!dict) {
-      Py_XDECREF (addr);
-      Py_XDECREF (netmask);
-      Py_XDECREF (braddr);
-      Py_XDECREF (dstaddr);
-      Py_DECREF (result);
-      close (sock);
-      return NULL;
-    }
-
-    if (addr)
-      PyDict_SetItemString (dict, "addr", addr);
-    if (netmask)
-      PyDict_SetItemString (dict, "netmask", netmask);
-    if (braddr)
-      PyDict_SetItemString (dict, "broadcast", braddr);
-    if (dstaddr)
-      PyDict_SetItemString (dict, "peer", dstaddr);
-
-    Py_XDECREF (addr);
-    Py_XDECREF (netmask);
-    Py_XDECREF (braddr);
-    Py_XDECREF (dstaddr);
-
-    if (!add_to_family (result, AF_INET, dict)) {
-      Py_DECREF (result);
-      close (sock);
-      return NULL;
-    }
+      found = TRUE;
   }
-
   close (sock);
 #endif /* HAVE_SOCKET_IOCTLS */
 
@@ -1279,10 +1293,198 @@ ifaddrs (PyObject *self, PyObject *args)
     return result;
   else {
     Py_DECREF (result);
-    PyErr_SetString (PyExc_ValueError, 
+    PyErr_SetString (PyExc_ValueError,
                      "You must specify a valid interface name.");
     return NULL;
   }
+}
+
+/* -- allifaddresses() --------------------------------------------------------- */
+static PyObject *
+allifaddrs (PyObject *self)
+{
+    PyObject *result;
+#if defined(WIN32)
+    PIP_ADAPTER_ADDRESSES pAdapterAddresses = NULL, pInfo = NULL;
+    ULONG ulBufferLength = 0;
+    DWORD dwRet;
+#elif HAVE_GETIFADDRS
+    struct ifaddrs *addrs = NULL;
+    struct ifaddrs *addr = NULL;
+#endif
+
+    result = PyDict_New ();
+
+    if (!result)
+        return NULL;
+#if defined(WIN32)
+    /* .. Win32 ............................................................... */
+
+  /* First, retrieve the adapter information.  We do this in a loop, in
+     case someone adds or removes adapters in the meantime. */
+  do {
+    dwRet = GetAdaptersAddresses (AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, NULL,
+                                  pAdapterAddresses, &ulBufferLength);
+
+    if (dwRet == ERROR_BUFFER_OVERFLOW) {
+      if (pAdapterAddresses)
+        free (pAdapterAddresses);
+      pAdapterAddresses = (PIP_ADAPTER_ADDRESSES)malloc (ulBufferLength);
+
+      if (!pAdapterAddresses) {
+        Py_DECREF (result);
+        PyErr_SetString (PyExc_MemoryError, "Not enough memory");
+        return NULL;
+      }
+    }
+  } while (dwRet == ERROR_BUFFER_OVERFLOW);
+
+  /* If we failed, then fail in Python too */
+  if (dwRet != ERROR_SUCCESS && dwRet != ERROR_NO_DATA) {
+    Py_DECREF (result);
+    if (pAdapterAddresses)
+      free (pAdapterAddresses);
+
+    PyErr_SetString (PyExc_OSError,
+                     "Unable to obtain adapter information.");
+    return NULL;
+  }
+
+  for (pInfo = pAdapterAddresses; pInfo; pInfo = pInfo->Next) {
+        PyObject* dict = winifaddrinfo(pInfo);
+
+        if(!dict)
+            continue;
+
+        PyObject *ifname = PyUnicode_FromString (pInfo->AdapterName);
+        PyDict_SetItem(result, ifname, dict);
+	Py_XDECREF(ifname);
+  }
+
+  free ((void *)pAdapterAddresses);
+#elif HAVE_GETIFADDRS
+    /* .. UNIX, with getifaddrs() ............................................. */
+
+  if (getifaddrs (&addrs) < 0) {
+    Py_DECREF (result);
+    PyErr_SetFromErrno (PyExc_OSError);
+    return NULL;
+  }
+
+  for (addr = addrs; addr; addr = addr->ifa_next) {
+    PyObject *ifinfo = getifaddrsinfo(addr);
+    if(!ifinfo)
+        continue;
+
+    PyObject *ifname = PyUnicode_FromString (addr->ifa_name);
+    PyObject* dict;
+    if (PyDict_Contains(result, ifname)) {
+        dict = PyDict_GetItem(result, ifname);
+    } else {
+	dict = PyDict_New ();
+        PyDict_SetItem(result, ifname, dict);
+    }
+
+    Py_XDECREF(ifname);    
+
+    if(!add_to_family (dict, addr->ifa_addr->sa_family, ifinfo)) {
+      Py_DECREF (dict);
+      freeifaddrs (addrs);
+      return NULL;
+    }
+
+  }
+
+  freeifaddrs (addrs);
+#elif HAVE_SOCKET_IOCTLS && HAVE_SIOCGIFCONF
+  /* .. UNIX, with SIOC ioctls() ............................................ */
+  int sock = socket(AF_INET, SOCK_DGRAM, 0);
+
+  if (sock < 0) {
+    Py_DECREF (result);
+    PyErr_SetFromErrno (PyExc_OSError);
+    return NULL;
+  }
+  int fd = socket (AF_INET, SOCK_DGRAM, 0);
+  struct CNAME(ifconf) ifc;
+  int len = -1;
+
+  if (fd < 0) {
+    PyErr_SetFromErrno (PyExc_OSError);
+    return NULL;
+  }
+
+  // Try to find out how much space we need
+#if HAVE_SIOCGSIZIFCONF
+  if (ioctl (fd, SIOCGSIZIFCONF, &len) < 0)
+    len = -1;
+#elif HAVE_SIOCGLIFNUM
+  { struct lifnum lifn;
+    lifn.lifn_family = AF_UNSPEC;
+    lifn.lifn_flags = LIFC_NOXMIT | LIFC_TEMPORARY | LIFC_ALLZONES;
+    ifc.lifc_family = AF_UNSPEC;
+    ifc.lifc_flags = LIFC_NOXMIT | LIFC_TEMPORARY | LIFC_ALLZONES;
+    if (ioctl (fd, SIOCGLIFNUM, (char *)&lifn) < 0)
+      len = -1;
+    else
+      len = lifn.lifn_count;
+  }
+#endif
+
+  // As a last resort, guess
+  if (len < 0)
+    len = 64;
+
+  ifc.CNAME(ifc_len) = (int)(len * sizeof (struct CNAME(ifreq)));
+  ifc.CNAME(ifc_buf) = malloc (ifc.CNAME(ifc_len));
+
+  if (!ifc.CNAME(ifc_buf)) {
+    PyErr_SetString (PyExc_MemoryError, "Not enough memory");
+    close (fd);
+    return NULL;
+  }
+
+#if HAVE_SIOCGLIFNUM
+  if (ioctl (fd, SIOCGLIFCONF, &ifc) < 0) {
+#else
+  if (ioctl (fd, SIOCGIFCONF, &ifc) < 0) {
+#endif
+    free (ifc.CNAME(ifc_req));
+    PyErr_SetFromErrno (PyExc_OSError);
+    close (fd);
+    return NULL;
+  }
+  struct CNAME(ifreq) *pfreq = ifc.CNAME(ifc_req);
+  struct CNAME(ifreq) *pfreqend = (struct CNAME(ifreq) *)((char *)pfreq
+                                                          + ifc.CNAME(ifc_len));
+  while (pfreq < pfreqend) {
+      char* if_name = pfreq->CNAME(ifr_name);
+      PyObject *name = PyUnicode_FromString (if_name);
+      if (!PyDict_Contains(result, name))
+      {
+        PyObject* dict = socket_ioctls_info(if_name, sock);
+        PyDict_SetItem(result, name, dict);
+	Py_XDECREF(dict);
+      }
+
+#if !HAVE_SOCKADDR_SA_LEN
+    ++pfreq;
+#else
+    /* On some platforms, the ifreq struct can *grow*(!) if the socket address
+       is very long.  Mac OS X is such a platform. */
+    {
+      size_t len = sizeof (struct CNAME(ifreq));
+      if (pfreq->ifr_addr.sa_len > sizeof (struct sockaddr))
+        len = len - sizeof (struct sockaddr) + pfreq->ifr_addr.sa_len;
+        pfreq = (struct CNAME(ifreq) *)((char *)pfreq + len);
+    }
+#endif
+  }
+
+  free (ifc.CNAME(ifc_buf));
+  close (fd);
+#endif /* HAVE_SOCKET_IOCTLS */
+    return result;
 }
 
 /* -- interfaces() ---------------------------------------------------------- */
@@ -1344,14 +1546,12 @@ interfaces (PyObject *self)
 #elif HAVE_GETIFADDRS
   /* .. UNIX, with getifaddrs() ............................................. */
 
-  const char *prev_name = NULL;
   struct ifaddrs *addrs = NULL;
   struct ifaddrs *addr = NULL;
 
-  result = PyList_New (0);
+  PyObject *dictionary = PyDict_New();
 
   if (getifaddrs (&addrs) < 0) {
-    Py_DECREF (result);
     PyErr_SetFromErrno (PyExc_OSError);
     return NULL;
   }
@@ -1360,15 +1560,10 @@ interfaces (PyObject *self)
     if (addr->ifa_name == NULL)
       continue;
 
-    if (!prev_name || strncmp (addr->ifa_name, prev_name, IFNAMSIZ) != 0) {
-      PyObject *ifname = PyUnicode_FromString (addr->ifa_name);
-    
-      if (!PySequence_Contains (result, ifname))
-        PyList_Append (result, ifname);
-      Py_DECREF (ifname);
-      prev_name = addr->ifa_name;
-    }
+    PyDict_SetItemString(dictionary, addr->ifa_name, Py_None);
   }
+  
+  result = PyMapping_Keys(dictionary);
 
   freeifaddrs (addrs);
 #elif HAVE_SIOCGIFCONF
@@ -2540,26 +2735,31 @@ gateways (PyObject *self)
 static PyMethodDef methods[] = {
   { "ifaddresses", (PyCFunction)ifaddrs, METH_VARARGS,
     "Obtain information about the specified network interface.\n"
-"\n"
-"Returns a dict whose keys are equal to the address family constants,\n"
-"e.g. netifaces.AF_INET, and whose values are a list of addresses in\n"
-"that family that are attached to the network interface." },
+    "\n"
+    "Returns a dict whose keys are equal to the address family constants,\n"
+    "e.g. netifaces.AF_INET, and whose values are a list of addresses in\n"
+    "that family that are attached to the network interface." },
+  { "allifaddresses", (PyCFunction)allifaddrs, METH_NOARGS,
+    "Obtain information about all network interfaces.\n"
+    "\n"
+    "Returns a dict whose keys are equal to the network interface name,\n"
+    "e.g. 'eth0', and whose value is dict of (key: family_address, value: network_interface_info) " },
   { "interfaces", (PyCFunction)interfaces, METH_NOARGS,
     "Obtain a list of the interfaces available on this machine." },
   { "gateways", (PyCFunction)gateways, METH_NOARGS,
     "Obtain a list of the gateways on this machine.\n"
-"\n"
-"Returns a dict whose keys are equal to the address family constants,\n"
-"e.g. netifaces.AF_INET, and whose values are a list of tuples of the\n"
-"format (<address>, <interface>, <is_default>).\n"
-"\n"
-"There is also a special entry with the key 'default', which you can use\n"
-"to quickly obtain the default gateway for a particular address family.\n"
-"\n"
-"There may in general be multiple gateways; different address\n"
-"families may have different gateway settings (e.g. AF_INET vs AF_INET6)\n"
-"and on some systems it's also possible to have interface-specific\n"
-"default gateways.\n" },
+    "\n"
+    "Returns a dict whose keys are equal to the address family constants,\n"
+    "e.g. netifaces.AF_INET, and whose values are a list of tuples of the\n"
+    "format (<address>, <interface>, <is_default>).\n"
+    "\n"
+    "There is also a special entry with the key 'default', which you can use\n"
+    "to quickly obtain the default gateway for a particular address family.\n"
+    "\n"
+    "There may in general be multiple gateways; different address\n"
+    "families may have different gateway settings (e.g. AF_INET vs AF_INET6)\n"
+    "and on some systems it's also possible to have interface-specific\n"
+    "default gateways.\n" },
   { NULL, NULL, 0, NULL }
 };
 

--- a/pypi_windows_packages.bat
+++ b/pypi_windows_packages.bat
@@ -4,9 +4,11 @@ C:\Python35\python.exe setup.py clean bdist_egg bdist_wininst bdist_wheel %*
 C:\Python36\python.exe setup.py clean bdist_egg bdist_wininst bdist_wheel %*
 C:\Python37\python.exe setup.py clean bdist_egg bdist_wininst bdist_wheel %*
 C:\Python38\python.exe setup.py clean bdist_egg bdist_wininst bdist_wheel %*
+C:\Python39\python.exe setup.py clean bdist_egg bdist_wininst bdist_wheel %*
 C:\Python27_32\python.exe setup.py clean bdist_egg bdist_wininst bdist_wheel %*
 C:\Python34_32\python.exe setup.py clean bdist_egg bdist_wininst bdist_wheel %*
 C:\Python35_32\python.exe setup.py clean bdist_egg bdist_wininst bdist_wheel %*
 C:\Python36_32\python.exe setup.py clean bdist_egg bdist_wininst bdist_wheel %*
 C:\Python37_32\python.exe setup.py clean bdist_egg bdist_wininst bdist_wheel %*
 C:\Python38_32\python.exe setup.py clean bdist_egg bdist_wininst bdist_wheel %*
+C:\Python39_32\python.exe setup.py clean bdist_egg bdist_wininst bdist_wheel %*

--- a/test.py
+++ b/test.py
@@ -48,3 +48,18 @@ for family in default_gateways:
     fam_name = netifaces.address_families[family]
     gateway, interface = default_gateways[family]
     print('  %s: %s (via %s)' % (fam_name, gateway, interface))
+
+print('')
+
+print('Getting information about all available interfaces: ')
+all_interfaces = netifaces.allifaddresses()
+for if_name, if_info in all_interfaces.items():
+    all_Addrs = netifaces.ifaddresses(if_name)
+
+    if all_Addrs == if_info:
+        print('     Information for %s from netifaces.allifaddresses()\n'
+              '     are equal with info from netifaces.ifaddresses(\'%s\')' % (if_name, if_name))
+    else:
+        print('     Information for %s from netifaces.allifaddresses()\n'
+              '     are NOT EQUAL with info from netifaces.ifaddresses(\'%s\')!!!' % (if_name, if_name))
+    print('')


### PR DESCRIPTION
Hi al45tair!

I would like to share this change with you, because during of dealing with my master thesis i have found a problem with getting big amount of network interfaces. Problem which i'm dealing is described here: https://bugzilla.redhat.com/show_bug.cgi?id=1582317
For big amount of network interface it takes a long time (for 5 000 NIC it's about 7 minutes) to get all needed information (like ip, netmask etc..).  

I created testing scripts which i used for creating ,,dummy" NIC on my virtual machine and then i tested how long it takes to load all information about all available interfaces. So testing script for module Netifaces was like:
`
import netifaces

addrs = []
interfaces = netifaces.interfaces()
for interface in interfaces:
    addrs.append(netifaces.ifaddresses(interface))
`
Results of tests are in the table below. The first column presents count of NIC available on my virtual machine. The second column presents how long it takes time to load all information about all NICs. (Values are in seconds)

![Capture](https://user-images.githubusercontent.com/37656709/115702027-b7c50200-a368-11eb-8add-9c9101f7de4c.PNG)

Graph below shows that loading all information has exponential grow:
![Speed test](https://user-images.githubusercontent.com/37656709/115701556-340b1580-a368-11eb-81e1-6d87dd746175.png)

At the first time i thought that problem is already describe here https://github.com/al45tair/netifaces/issues/15, but it's not the same thing. In this pull request i have created optimization which speeds up loading names of interface about 3 time. Instead of using PySequence_Contains (..) i used dictionary, where key is name of interface and value is ,,null" then as result is returned key set from dictionary. So this was my first try.

After that, i found out where is the main problem. It's in the logic. Let's suppose we have PC with 1 000 NIC. Every NIC supports AF_INET, AF_INET6 and AF_PACKET. So library <ifaddrs.h>, respectively function getifaddrs (..) returns 3 000 records in the list (Windows library behaves same). 
Now let's see on the code i have put above. This statement ,,interfaces = netifaces.interfaces()" does almost 3 000 iterations and returns list with size 1 000 (that's OK). Next statement is for loop where for each interface name is returned information about NIC and this informatio is added to list. Let's see closely on netifaces.ifaddresses(interface). Calling this function it makes again about 3 000 iteration, but only for one interface (because of finding interface with equal name on the input). It means that total count of iteration is 1 000 (NIC count) * 3 000 (calling netifaces.ifaddresses(..)). Therefore i have created new function called allifaddresses() which loads all information about all interfaces at the same time.  I used python3.9 so i decided to add tests for this version to travis.yml. And I added to test.py new smoke test for allifaddresses() function.

After this change the testing results are visible below:

![repair](https://user-images.githubusercontent.com/37656709/115707080-a54dc700-a36e-11eb-9457-4e1d8a437c33.PNG)

These changes were tested on Linux/windows/MacOS  and everything was OK.